### PR TITLE
Fix: Add Summary Field to Theme1 Resume Template

### DIFF
--- a/src/Theme/Theme1/Theme1.jsx
+++ b/src/Theme/Theme1/Theme1.jsx
@@ -9,7 +9,7 @@ import ResumeContext from '../../Context/ResumeContext'
 const Theme1 = (props) => {
     const { checkProj, checkWork, checkAward } = useContext(ResumeContext)
     const { themeData, componentRef } = props;
-    const { name, profile, address, phone, email, skill } = themeData.personalData;
+    const { name, profile, address, phone, email, skill, summary } = themeData.personalData;
     const { projectTitles, projectDesc } = themeData.projectData;
     const { educationTitles, educationDesc } = themeData.educationData;
     const { workTitles, workDesc } = themeData.workData;
@@ -31,6 +31,9 @@ const Theme1 = (props) => {
                         <Heading as='h3' size='md' className='mt-1 mb-2'>
                             {profile}
                         </Heading>
+                        <Text fontSize='md' className='my-2'>
+                          {summary}
+                        </Text>
                     </header>
                     {/* Skills Part  */}
                     <section id="skills" className='my-2'>


### PR DESCRIPTION
**Overview**
This PR addresses the issue where the "Your Summary" field was not displayed on the resume in the Theme1 template. The fix ensures that the summary entered by the user in UserDataCollect.jsx is rendered in the personal information section of the Theme1 template.

**Changes Made**

1. Modified src/Theme/Theme1/Theme1.jsx to destructure the summary field from themeData.personalData.
2. Added the summary field to the JSX in the <header> section, displaying it below the profile field and above the "TECHNICAL SKILLS" section.

**Impact**

1. The "Your Summary" field now correctly appears on the resume when using the Theme1 template.
2. No other functionality or styling was affected by this change.

**Screenshots**
Before: 
<img width="1440" alt="Screenshot 2025-05-10 at 8 03 46 PM" src="https://github.com/user-attachments/assets/86046cf0-fdb1-474e-9a20-7d8fcf4ad17d" />

After: 
<img width="1440" alt="Screenshot 2025-05-10 at 8 03 56 PM" src="https://github.com/user-attachments/assets/911f3f26-5986-4c62-afa9-09601b5efa7f" />

**Related Issue**
Closes #1 